### PR TITLE
Fix: when 'npm run format' get '[error] No files matching the pattern were found'

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "clean": "rimraf target results tmp",
-    "format": "prettier --write '**/*.js'",
+    "format": "prettier --write **/*.js",
     "build": "gatling build",
     "start": "gatling run --simulation computerdatabase",
     "recorder": "gatling recorder"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "clean": "rimraf target results",
-    "format": "prettier --write '**/*.ts'",
+    "format": "prettier --write **/*.ts",
     "check": "tsc --noEmit",
     "build": "tsc --noEmit && gatling build --typescript",
     "start": "tsc --noEmit && gatling run --typescript --simulation computerdatabase",


### PR DESCRIPTION
Fix for:

- JS:

npm run format

> gatling-js-demo@3.11.3 format
> prettier --write '**/*.js'

[error] No files matching the pattern were found: "'**/*.js'".

---
- TS:

npm run format

> gatling-ts-demo@3.11.3 format
> prettier --write '**/*.ts'

[error] No files matching the pattern were found: "'**/*.ts'".