### PR TITLE
chore: Add sample config files

### DIFF
--- a/javascript/resources/gatling.conf
+++ b/javascript/resources/gatling.conf
@@ -1,0 +1,118 @@
+#########################
+# Gatling Configuration #
+#########################
+
+# This file contains all the settings configurable for Gatling with their default values
+
+gatling {
+  core {
+    #encoding = "utf-8"                      # Encoding to use throughout Gatling for file and string manipulation
+    #elFileBodiesCacheMaxCapacity = 200      # Cache size for request body EL templates, set to 0 to disable
+    #rawFileBodiesCacheMaxCapacity = 200     # Cache size for request body raw files, set to 0 to disable
+    #rawFileBodiesInMemoryMaxSize = 10240    # Max bite size of raw files to be cached in memory
+    #pebbleFileBodiesCacheMaxCapacity = 200  # Cache size for request body Pebble templates, set to 0 to disable
+    #feederAdaptiveLoadModeThreshold = 100   # File size threshold (in MB). Below load eagerly in memory, above use batch mode with default buffer size
+    #shutdownTimeout = 10000                 # Milliseconds to wait for the actor system to shutdown
+    extract {
+      regex {
+        #cacheMaxCapacity = 200              # Cache size for the compiled regexes, set to 0 to disable caching
+      }
+      xpath {
+        #cacheMaxCapacity = 200              # Cache size for the compiled XPath queries,  set to 0 to disable caching
+      }
+      jsonPath {
+        #cacheMaxCapacity = 200              # Cache size for the compiled jsonPath queries, set to 0 to disable caching
+      }
+      css {
+        #cacheMaxCapacity = 200              # Cache size for the compiled CSS selectors queries,  set to 0 to disable caching
+      }
+    }
+  }
+  socket {
+    #connectTimeout = 10000                  # Timeout in millis for establishing a TCP socket
+    #tcpNoDelay = true
+    #soKeepAlive = false                     # if TCP keepalive configured at OS level should be used
+    #soReuseAddress = false
+  }
+  netty {
+    #useNativeTransport = true               # if Netty Linux native transport should be used instead of Java NIO
+    #useIoUring = false                      # if io_uring should be used instead of epoll if available
+    #allocator = "pooled"                    # switch to unpooled for unpooled ByteBufAllocator
+    #maxThreadLocalCharBufferSize = 200000   # Netty's default is 16k
+  }
+  ssl {
+    #useOpenSsl = true                       # if OpenSSL should be used instead of JSSE (only the latter can be debugged with -Djavax.net.debug=ssl)
+    #useOpenSslFinalizers = false            # if OpenSSL contexts should be freed with Finalizer or if using RefCounted is fine
+    #handshakeTimeout = 10000                # TLS handshake timeout in millis
+    #useInsecureTrustManager = true          # Use an insecure TrustManager that trusts all server certificates
+    #enabledProtocols = []                   # Array of enabled protocols for HTTPS, if empty use Netty's defaults
+    #enabledCipherSuites = []                # Array of enabled cipher suites for HTTPS, if empty enable all available ciphers
+    #sessionCacheSize = 0                    # SSLSession cache size, set to 0 to use JDK's default
+    #sessionTimeout = 0                      # SSLSession timeout in seconds, set to 0 to use JDK's default (24h)
+    #enableSni = true                        # When set to true, enable Server Name indication (SNI)
+    keyStore {
+      #type = ""                             # Type of SSLContext's KeyManagers store, possible values are jks and p12
+      #file = ""                             # Location of SSLContext's KeyManagers store
+      #password = ""                         # Password for SSLContext's KeyManagers store
+      #algorithm = ""                        # Algorithm used SSLContext's KeyManagers store, typically RSA
+    }
+    trustStore {
+      #type = ""                             # Type of SSLContext's TrustManagers store, possible values are jks and p12
+      #file = ""                             # Location of SSLContext's TrustManagers store
+      #password = ""                         # Password for SSLContext's TrustManagers store
+      #algorithm = ""                        # Algorithm used by SSLContext's TrustManagers store, typically RSA
+    }
+  }
+  charting {
+    #maxPlotPerSeries = 1000                 # Number of points per graph in Gatling reports
+    #useGroupDurationMetric = false          # Switch group timings from cumulated response time to group duration.
+    indicators {
+      #lowerBound = 800                      # Lower bound for the requests' response time to track in the reports and the console summary
+      #higherBound = 1200                    # Higher bound for the requests' response time to track in the reports and the console summary
+      #percentile1 = 50                      # Value for the 1st percentile to track in the reports, the console summary and Graphite
+      #percentile2 = 75                      # Value for the 2nd percentile to track in the reports, the console summary and Graphite
+      #percentile3 = 95                      # Value for the 3rd percentile to track in the reports, the console summary and Graphite
+      #percentile4 = 99                      # Value for the 4th percentile to track in the reports, the console summary and Graphite
+    }
+  }
+  http {
+    #fetchedCssCacheMaxCapacity = 200        # Cache size for CSS parsed content, set to 0 to disable
+    #fetchedHtmlCacheMaxCapacity = 200       # Cache size for HTML parsed content, set to 0 to disable
+    #perUserCacheMaxCapacity = 200           # Per virtual user cache size, set to 0 to disable
+    #warmUpUrl = "https://gatling.io"        # The URL to use to warm-up the HTTP stack (blank means disabled)
+    #pooledConnectionIdleTimeout = 60000     # Timeout in millis for a connection to stay idle in the pool
+    #requestTimeout = 60000                  # Timeout in millis for performing an HTTP request
+    #enableHostnameVerification = false      # When set to true, enable hostname verification: SSLEngine.setHttpsEndpointIdentificationAlgorithm("HTTPS")
+    dns {
+      #queryTimeout = 5000                   # Timeout in millis of each DNS query in millis
+      #maxQueriesPerResolve = 6              # Maximum allowed number of DNS queries for a given name resolution
+    }
+  }
+  jms {
+    #replyTimeoutScanPeriod = 1000           # scan period for timed out reply messages
+  }
+  data {
+    #writers = [console, file]               # The list of DataWriters to which Gatling write simulation data (currently supported : console, file, graphite)
+    #utcDateTime = true                      # Print date-times with the UTC zone instead of the System's default
+    console {
+      #light = false                         # When set to true, displays a light version without detailed request stats
+      #writePeriod = 5                       # Write interval, in seconds
+    }
+    file {
+      #bufferSize = 8192                     # FileDataWriter's internal data buffer size, in bytes
+    }
+    leak {
+      #noActivityTimeout = 30                # Period, in seconds, for which Gatling may have no activity before considering a leak may be happening
+    }
+    graphite {
+      #light = false                         # only send the all* stats
+      #host = "localhost"                    # The host where the Carbon server is located
+      #port = 2003                           # The port to which the Carbon server listens to (2003 is default for plaintext, 2004 is default for pickle)
+      #protocol = "tcp"                      # The protocol used to send data to Carbon (currently supported : "tcp", "udp")
+      #rootPathPrefix = "gatling"            # The common prefix of all metrics sent to Graphite
+      #bufferSize = 8192                     # Internal data buffer size, in bytes
+      #writePeriod = 1                       # Write period, in seconds
+    }
+    #enableAnalytics = true                  # Anonymous Usage Analytics (no tracking), please support
+  }
+}

--- a/javascript/resources/logback-test.xml
+++ b/javascript/resources/logback-test.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+		</encoder>
+		<immediateFlush>false</immediateFlush>
+	</appender>
+
+	<!-- uncomment and set to DEBUG to log all failing HTTP requests -->
+	<!-- uncomment and set to TRACE to log all HTTP requests -->
+	<!--<logger name="io.gatling.http.engine.response" level="TRACE" />-->
+
+	<root level="WARN">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</configuration>

--- a/typescript/resources/gatling.conf
+++ b/typescript/resources/gatling.conf
@@ -1,0 +1,118 @@
+#########################
+# Gatling Configuration #
+#########################
+
+# This file contains all the settings configurable for Gatling with their default values
+
+gatling {
+  core {
+    #encoding = "utf-8"                      # Encoding to use throughout Gatling for file and string manipulation
+    #elFileBodiesCacheMaxCapacity = 200      # Cache size for request body EL templates, set to 0 to disable
+    #rawFileBodiesCacheMaxCapacity = 200     # Cache size for request body raw files, set to 0 to disable
+    #rawFileBodiesInMemoryMaxSize = 10240    # Max bite size of raw files to be cached in memory
+    #pebbleFileBodiesCacheMaxCapacity = 200  # Cache size for request body Pebble templates, set to 0 to disable
+    #feederAdaptiveLoadModeThreshold = 100   # File size threshold (in MB). Below load eagerly in memory, above use batch mode with default buffer size
+    #shutdownTimeout = 10000                 # Milliseconds to wait for the actor system to shutdown
+    extract {
+      regex {
+        #cacheMaxCapacity = 200              # Cache size for the compiled regexes, set to 0 to disable caching
+      }
+      xpath {
+        #cacheMaxCapacity = 200              # Cache size for the compiled XPath queries,  set to 0 to disable caching
+      }
+      jsonPath {
+        #cacheMaxCapacity = 200              # Cache size for the compiled jsonPath queries, set to 0 to disable caching
+      }
+      css {
+        #cacheMaxCapacity = 200              # Cache size for the compiled CSS selectors queries,  set to 0 to disable caching
+      }
+    }
+  }
+  socket {
+    #connectTimeout = 10000                  # Timeout in millis for establishing a TCP socket
+    #tcpNoDelay = true
+    #soKeepAlive = false                     # if TCP keepalive configured at OS level should be used
+    #soReuseAddress = false
+  }
+  netty {
+    #useNativeTransport = true               # if Netty Linux native transport should be used instead of Java NIO
+    #useIoUring = false                      # if io_uring should be used instead of epoll if available
+    #allocator = "pooled"                    # switch to unpooled for unpooled ByteBufAllocator
+    #maxThreadLocalCharBufferSize = 200000   # Netty's default is 16k
+  }
+  ssl {
+    #useOpenSsl = true                       # if OpenSSL should be used instead of JSSE (only the latter can be debugged with -Djavax.net.debug=ssl)
+    #useOpenSslFinalizers = false            # if OpenSSL contexts should be freed with Finalizer or if using RefCounted is fine
+    #handshakeTimeout = 10000                # TLS handshake timeout in millis
+    #useInsecureTrustManager = true          # Use an insecure TrustManager that trusts all server certificates
+    #enabledProtocols = []                   # Array of enabled protocols for HTTPS, if empty use Netty's defaults
+    #enabledCipherSuites = []                # Array of enabled cipher suites for HTTPS, if empty enable all available ciphers
+    #sessionCacheSize = 0                    # SSLSession cache size, set to 0 to use JDK's default
+    #sessionTimeout = 0                      # SSLSession timeout in seconds, set to 0 to use JDK's default (24h)
+    #enableSni = true                        # When set to true, enable Server Name indication (SNI)
+    keyStore {
+      #type = ""                             # Type of SSLContext's KeyManagers store, possible values are jks and p12
+      #file = ""                             # Location of SSLContext's KeyManagers store
+      #password = ""                         # Password for SSLContext's KeyManagers store
+      #algorithm = ""                        # Algorithm used SSLContext's KeyManagers store, typically RSA
+    }
+    trustStore {
+      #type = ""                             # Type of SSLContext's TrustManagers store, possible values are jks and p12
+      #file = ""                             # Location of SSLContext's TrustManagers store
+      #password = ""                         # Password for SSLContext's TrustManagers store
+      #algorithm = ""                        # Algorithm used by SSLContext's TrustManagers store, typically RSA
+    }
+  }
+  charting {
+    #maxPlotPerSeries = 1000                 # Number of points per graph in Gatling reports
+    #useGroupDurationMetric = false          # Switch group timings from cumulated response time to group duration.
+    indicators {
+      #lowerBound = 800                      # Lower bound for the requests' response time to track in the reports and the console summary
+      #higherBound = 1200                    # Higher bound for the requests' response time to track in the reports and the console summary
+      #percentile1 = 50                      # Value for the 1st percentile to track in the reports, the console summary and Graphite
+      #percentile2 = 75                      # Value for the 2nd percentile to track in the reports, the console summary and Graphite
+      #percentile3 = 95                      # Value for the 3rd percentile to track in the reports, the console summary and Graphite
+      #percentile4 = 99                      # Value for the 4th percentile to track in the reports, the console summary and Graphite
+    }
+  }
+  http {
+    #fetchedCssCacheMaxCapacity = 200        # Cache size for CSS parsed content, set to 0 to disable
+    #fetchedHtmlCacheMaxCapacity = 200       # Cache size for HTML parsed content, set to 0 to disable
+    #perUserCacheMaxCapacity = 200           # Per virtual user cache size, set to 0 to disable
+    #warmUpUrl = "https://gatling.io"        # The URL to use to warm-up the HTTP stack (blank means disabled)
+    #pooledConnectionIdleTimeout = 60000     # Timeout in millis for a connection to stay idle in the pool
+    #requestTimeout = 60000                  # Timeout in millis for performing an HTTP request
+    #enableHostnameVerification = false      # When set to true, enable hostname verification: SSLEngine.setHttpsEndpointIdentificationAlgorithm("HTTPS")
+    dns {
+      #queryTimeout = 5000                   # Timeout in millis of each DNS query in millis
+      #maxQueriesPerResolve = 6              # Maximum allowed number of DNS queries for a given name resolution
+    }
+  }
+  jms {
+    #replyTimeoutScanPeriod = 1000           # scan period for timed out reply messages
+  }
+  data {
+    #writers = [console, file]               # The list of DataWriters to which Gatling write simulation data (currently supported : console, file, graphite)
+    #utcDateTime = true                      # Print date-times with the UTC zone instead of the System's default
+    console {
+      #light = false                         # When set to true, displays a light version without detailed request stats
+      #writePeriod = 5                       # Write interval, in seconds
+    }
+    file {
+      #bufferSize = 8192                     # FileDataWriter's internal data buffer size, in bytes
+    }
+    leak {
+      #noActivityTimeout = 30                # Period, in seconds, for which Gatling may have no activity before considering a leak may be happening
+    }
+    graphite {
+      #light = false                         # only send the all* stats
+      #host = "localhost"                    # The host where the Carbon server is located
+      #port = 2003                           # The port to which the Carbon server listens to (2003 is default for plaintext, 2004 is default for pickle)
+      #protocol = "tcp"                      # The protocol used to send data to Carbon (currently supported : "tcp", "udp")
+      #rootPathPrefix = "gatling"            # The common prefix of all metrics sent to Graphite
+      #bufferSize = 8192                     # Internal data buffer size, in bytes
+      #writePeriod = 1                       # Write period, in seconds
+    }
+    #enableAnalytics = true                  # Anonymous Usage Analytics (no tracking), please support
+  }
+}

--- a/typescript/resources/logback-test.xml
+++ b/typescript/resources/logback-test.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+		</encoder>
+		<immediateFlush>false</immediateFlush>
+	</appender>
+
+	<!-- uncomment and set to DEBUG to log all failing HTTP requests -->
+	<!-- uncomment and set to TRACE to log all HTTP requests -->
+	<!--<logger name="io.gatling.http.engine.response" level="TRACE" />-->
+
+	<root level="WARN">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</configuration>


### PR DESCRIPTION
~Draft pull request - do not merge until we publish a new version of gatling-js with gatling/gatling-js#32 (otherwise users will get a bunch of annoying logs when running tests locally, due to the duplicated `logback-test.xml` file, even though the one in the user's project takes priority).~

Change released in version 3.11.7.

-----

Add sample files for:
- logback-test.xml (to configure Gatling's logging behavior)
- gatling.conf (Gatling's main configuration file)